### PR TITLE
Generate correct file paths on both Windows and POSIX systems

### DIFF
--- a/src/feature/intelliSense/managers/intellisenseGraphManager.ts
+++ b/src/feature/intelliSense/managers/intellisenseGraphManager.ts
@@ -576,7 +576,7 @@ export class IntellisenseGraphManager {
             let environment = EnvironmentManager.get().environment;
 
             let extension = vscode.extensions.getExtension(constant.ExtensionId);
-            let folderPath =  extension.extensionPath +  '\\resources';
+            let folderPath = path.join(extension.extensionPath, 'resources');
 
             let folders = fs.readdirSync(folderPath)
                 .filter(

--- a/src/managers/fileSystemLoaderServiceSpecificationManagerDecorator.ts
+++ b/src/managers/fileSystemLoaderServiceSpecificationManagerDecorator.ts
@@ -34,8 +34,7 @@ export class FileSystemLoaderServiceSpecificationManagerDecorator extends Servic
                 const extension = path.extname(filename);
                 
                 if(extension === '.json') {
-                    
-                    const filePath = folderPath + '\\' + filename;
+                    const filePath = path.join(folderPath, filename)
                     let specificationItems = this.loadSpecificationItemFromFile(filePath);
 
                     for(let specificationItem of specificationItems) {
@@ -108,7 +107,7 @@ export class FileSystemLoaderServiceSpecificationManagerDecorator extends Servic
         if(environment && environment.hasVersion) {
 
             let extension = vscode.extensions.getExtension(constant.ExtensionId);
-            folderPath =  extension.extensionPath +  '\\resources\\rest-api-spec';
+            folderPath = path.join(extension.extensionPath, 'resources', 'rest-api-spec');
 
             let folders = fs.readdirSync(folderPath)
                 .filter(
@@ -118,7 +117,7 @@ export class FileSystemLoaderServiceSpecificationManagerDecorator extends Servic
             let closest = Version.getClosest(environment.version, folders);
 
             if(closest) {
-                folderPath = folderPath + '\\' + closest.toString();
+                folderPath = path.join(folderPath, closest.toString());
             } else {
                 folderPath = null;
             }

--- a/src/services/httpService.ts
+++ b/src/services/httpService.ts
@@ -2,6 +2,7 @@
 
 import * as vscode from 'vscode';
 import * as fs from 'fs';
+import * as path from 'path';
 
 export class HttpService {
 
@@ -12,7 +13,7 @@ export class HttpService {
     constructor(portNumber:number, rootFolder:string) {
         this._outputChannel = vscode.window.createOutputChannel('Elasticdeveloper HTTP');
         this._portNumber = portNumber;
-        this._rootFolder = rootFolder + '\\.wwwroot';
+        this._rootFolder = path.join(rootFolder, '.wwwroot');
     }
 
     public async start() {


### PR DESCRIPTION
Hi @Crasnam,

thank you for this extension! I wanted to try autocomplete, but it was not working. It seems that file paths were generated using `\` which doesn't work on my setup.

This change resolves the issue and tests stay green.

I'm not familiar with the development of the Visual Studio Code extensions so hopefully, this change won't break anything else...